### PR TITLE
feat(tuyaopen): add tuyaopen license adapter stub

### DIFF
--- a/beken_os/application.mk
+++ b/beken_os/application.mk
@@ -153,6 +153,7 @@ INCLUDES += -I./beken378/func/$(WPA_VERSION)/bk_patch
 #INCLUDES += -I./beken378/func/lwip_intf/lwip-2.0.2/src/include/lwip
 INCLUDES += -I../tuyaos/tuyaos_adapter/include
 INCLUDES += -I../tuyaos/tuyaos_adapter/include/lwip
+INCLUDES += -I../tuyaos/tuyaos_adapter/tuyaopen
 INCLUDES += -I./beken378/func/temp_detect
 INCLUDES += -I./beken378/func/spidma_intf
 INCLUDES += -I./beken378/func/rwnx_intf
@@ -725,6 +726,7 @@ SRC_C += ./beken378/os/str_arch.c
 #examples for customer
 TY_SRC_DIRS += $(shell find ../tuyaos/tuyaos_adapter/src -type d)
 TY_SRC_DIRS += $(shell find ../tuyaos/tuyaos_adapter/include -type d)
+TY_SRC_DIRS += $(shell find ../tuyaos/tuyaos_adapter/tuyaopen -type d)
 
 SRC_C += $(foreach dir, $(TY_SRC_DIRS), $(wildcard $(dir)/*.c)) # need export
 SRC_C += $(foreach dir, $(TY_SRC_DIRS), $(wildcard $(dir)/*.s)) 

--- a/tuyaos/tuyaos_adapter/tuyaopen/tuyaopen_license.c
+++ b/tuyaos/tuyaos_adapter/tuyaopen/tuyaopen_license.c
@@ -1,0 +1,54 @@
+/**
+ * @file tuyaopen_license.c
+ * @brief tuyaopen_license module is used to 
+ * @version 0.1
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#include "tuyaopen_license.h"
+
+/***********************************************************
+************************macro define************************
+***********************************************************/
+
+
+/***********************************************************
+***********************typedef define***********************
+***********************************************************/
+
+
+/***********************************************************
+********************function declaration********************
+***********************************************************/
+
+
+/***********************************************************
+***********************variable define**********************
+***********************************************************/
+
+
+/***********************************************************
+***********************function define**********************
+***********************************************************/
+
+/**
+ * @brief Write license data
+ * @param[in] data Pointer to license data
+ * @param[in] data_len Length of license data
+ * @return OPRT_NOT_SUPPORTED - operation not supported
+ */
+int tuyaopen_license_write(const char *data, const uint32_t data_len)
+{
+    return OPRT_NOT_SUPPORTED;
+}
+
+/**
+ * @brief Read license data
+ * @param[out] data Pointer to store license data address
+ * @param[out] data_len Pointer to store license data length
+ * @return OPRT_NOT_SUPPORTED - operation not supported
+ */
+int tuyaopen_license_read(char **data, uint32_t *data_len)
+{
+    return OPRT_NOT_SUPPORTED;
+}

--- a/tuyaos/tuyaos_adapter/tuyaopen/tuyaopen_license.h
+++ b/tuyaos/tuyaos_adapter/tuyaopen/tuyaopen_license.h
@@ -1,0 +1,51 @@
+/**
+ * @file tuyaopen_license.h
+ * @brief tuyaopen_license module is used to 
+ * @version 0.1
+ * @copyright Copyright (c) 2021-2026 Tuya Inc. All Rights Reserved.
+ */
+
+#ifndef __TUYAOPEN_LICENSE_H__
+#define __TUYAOPEN_LICENSE_H__
+
+#include "tuya_cloud_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***********************************************************
+************************macro define************************
+***********************************************************/
+
+
+/***********************************************************
+***********************typedef define***********************
+***********************************************************/
+
+
+/***********************************************************
+********************function declaration********************
+***********************************************************/
+
+/**
+ * @brief Write license data
+ * @param[in] data Pointer to license data
+ * @param[in] data_len Length of license data
+ * @return 0 on success, non-zero on failure
+ */
+int tuyaopen_license_write(const char *data, const uint32_t data_len);
+
+/**
+ * @brief Read license data
+ * @param[out] data Pointer to store license data address
+ * @param[out] data_len Pointer to store license data length
+ * @return 0 on success, non-zero on failure
+ */
+int tuyaopen_license_read(char **data, uint32_t *data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TUYAOPEN_LICENSE_H__ */


### PR DESCRIPTION
Add tuyaopen_license.{c,h} stubs returning OPRT_NOT_SUPPORTED and wire the tuyaos_adapter/tuyaopen directory into the beken build (application.mk).